### PR TITLE
Add option to use custom OSM data

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -168,6 +168,9 @@ if config["enable"].get("download_osm_data", True):
     rule download_osm_data:
         params:
             countries=config["countries"],
+            store_path_resources="resources/" + RDIR + "osm/raw",
+            store_path_data="data/osm",
+            custom_data_path="data/custom/osm",
         output:
             cables="resources/" + RDIR + "osm/raw/all_raw_cables.geojson",
             generators="resources/" + RDIR + "osm/raw/all_raw_generators.geojson",

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -509,6 +509,7 @@ custom_data:
   gas_network: false # If "True" then a custom .csv file must be placed in "resources/custom_data/pipelines.csv" , If "False" the user can choose btw "greenfield" or Model built-in datasets. Please refer to ["sector"] below.
   export_ports: false # If "True" then a custom .csv file must be placed in "data/custom/export_ports.csv"
   airports: false # If "True" then a custom .csv file must be placed in "data/custom/airports.csv". Data format for aiports must be in the format of the airports.csv file in the data folder.
+  osm_data: true # if "True" then custom file for osm (pbf and power files) must be placed in "data/custom/osm" folder. 
 
 industry:
   reference_year: 2015

--- a/scripts/download_osm_data.py
+++ b/scripts/download_osm_data.py
@@ -99,12 +99,20 @@ if __name__ == "__main__":
 
     run = snakemake.config.get("run", {})
     RDIR = run["name"] + "/" if run.get("name") else ""
-    store_path_resources = Path.joinpath(
-        Path(BASE_DIR), "resources", RDIR, "osm", "raw"
-    )
-    store_path_data = Path.joinpath(Path(BASE_DIR), "data", "osm")
+    store_path_resources = Path(snakemake.params.store_path_resources)
+    store_path_data = Path(snakemake.params.store_path_data)
     country_list = country_list_to_geofk(snakemake.params.countries)
+    custom_data = snakemake.config.get("custom_data", {}).get("osm_data")
+    custom_data_path = Path(snakemake.params.get("custom_data_path", "data/custom/osm"))
 
+    # allow for custom data usage
+    if custom_data:
+        logger.info(
+            "Custom OSM data usage is activated. Skipping the download of OSM data."
+        )
+        os.makedirs(store_path_data, exist_ok=True)
+        shutil.copytree(custom_data_path, store_path_data, dirs_exist_ok=True)
+   
     eo.save_osm_data(
         primary_name="power",
         region_list=country_list,


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

Adds optional support for using custom OSM data instead of downloading from Geofabrik.

### Changes
- New config flag: custom_data.osm_data
- Snakefile: new params for custom OSM path and store paths
- scripts/download_osm_data.py: if enabled, copies files from data/custom/osm to data/osm and skips download

### Usage
Put your OSM files in data/custom/osm (or set a different path via Snakemake params)
Set custom_data.osm_data: true in your config and run the download_osm_data rule

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
