### PR TITLE
Add Historical OSM Data Test Configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test:
 	snakemake solve_all_networks -call --configfile config.tutorial.yaml configs/scenarios/config.NG.yaml
 	snakemake solve_all_networks_monte -call --configfile config.tutorial.yaml test/config.monte_carlo.yaml
 	snakemake solve_all_networks -call --configfile config.tutorial.yaml test/config.landlock.yaml
+	snakemake solve_all_networks -call --configfile config.tutorial.yaml test/config.historical.yaml
 	snakemake -c4 solve_sector_networks --configfile config.tutorial.yaml test/config.sector.yaml
 	snakemake -c4 solve_sector_networks_myopic --configfile config.tutorial.yaml test/config.myopic.yaml
 	echo "All tests completed successfully."
@@ -27,6 +28,7 @@ clean:
 	snakemake -j1 solve_all_networks --delete-all-output --configfile config.tutorial.yaml configs/scenarios/config.NG.yaml
 	snakemake -j1 solve_all_networks_monte --delete-all-output --configfile test/config.monte_carlo.yaml
 	snakemake -j1 run_all_scenarios --delete-all-output --configfile test/config.landlock.yaml
+	snakemake -j1 solve_all_networks --delete-all-output --configfile config.tutorial.yaml test/config.historical.yaml
 	snakemake -j1 solve_sector_networks --delete-all-output --configfile test/config.sector.yaml
 	snakemake -j1 solve_sector_networks_myopic --delete-all-output --configfile config.tutorial.yaml test/config.myopic.yaml
 	echo "Clean-up complete."

--- a/test/config.historical.yaml
+++ b/test/config.historical.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+### TEST CONFIG FOR HISTORICAL OSM DATA FEATURE ###
+version: 0.7.0
+
+run:
+  name: "historical_test"
+  shared_cutouts: true # set to true to share the default cutout(s) across runs
+  base_config: config.tutorial.yaml  # base configuration file
+
+enable:
+  retrieve_cost_data: false
+
+# OpenStreetMap (OSM) data configuration - testing historical feature
+osm_data:
+  source: "historical" # Test the historical data download feature
+  target_date: "2020-01-01" # Use a specific historical date for testing

--- a/test/utils/obj_ref.csv
+++ b/test/utils/obj_ref.csv
@@ -5,6 +5,7 @@
 folder,file,objective
 tutorial,elec_s_6_ec_lcopt_Co2L-4H_python.log,2839036244.0
 custom,elec_s_6_ec_lcopt_Co2L-4H_python.log,2669287067.0
+historical_test,elec_s_6_ec_lcopt_Co2L-4H_python.log,NA
 NG,elec_s_5_ec_lcopt_Co2L-4H_python.log,2671484779.0
 monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m0_python.log,1825115005.0
 monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m1_python.log,10092009600.0

--- a/test/utils/obj_ref.csv
+++ b/test/utils/obj_ref.csv
@@ -5,7 +5,7 @@
 folder,file,objective
 tutorial,elec_s_6_ec_lcopt_Co2L-4H_python.log,2839036244.0
 custom,elec_s_6_ec_lcopt_Co2L-4H_python.log,2669287067.0
-historical_test,elec_s_6_ec_lcopt_Co2L-4H_python.log,NA
+historical_test,elec_s_6_ec_lcopt_Co2L-4H_python.log,3153.56
 NG,elec_s_5_ec_lcopt_Co2L-4H_python.log,2671484779.0
 monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m0_python.log,1825115005.0
 monte-carlo,elec_s_6_ec_lcopt_Co2L-4H_m1_python.log,10092009600.0


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
This PR adds a test configuration to validate the earth-osm historical data download feature.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented including ammending docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
